### PR TITLE
Fix void-fall death on teleport (1.6.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The addon is small — the production code is three classes:
 ## Build & test
 
 ```bash
-mvn clean package        # build the shaded jar into target/
+mvn clean package        # build the jar into target/
 mvn test                 # run the JUnit 5 + MockBukkit suite
 mvn test -Dtest=VoidListenerTest          # run a single test class
 mvn test -Dtest=VoidListenerTest#testOverworldFallTeleportsToNether   # single method
@@ -22,7 +22,7 @@ mvn test -Dtest=VoidListenerTest#testOverworldFallTeleportsToNether   # single m
 
 - **Java 21**, Paper `1.21.11`, BentoBox `3.14.0-SNAPSHOT` (see `pom.xml` properties).
 - Dependencies (BentoBox, Paper) are `provided` and resolved from the **PaperMC**, **CodeMC/BentoBoxWorld**, and **JitPack** repos, not Maven Central. The first build needs network access.
-- The build produces `target/VoidPortals-<version>.jar`; copy it into a BentoBox server's `addons/` folder to test in-game. Drop the `original-*.jar` (pre-shade) — use the shaded one.
+- The build produces `target/VoidPortals-<version>.jar`; copy it into a BentoBox server's `addons/` folder to test in-game. (All dependencies are `provided`/`test` scope, so there is nothing to shade — the jar is the plain addon classes plus resources.)
 - Version is driven by the `build.version` property and Jenkins env vars (`BUILD_NUMBER`, `GIT_BRANCH`) via the `ci`/`master` profiles — `addon.yml` and `plugin.yml` use filtered `${...}` placeholders, so don't hardcode versions there.
 
 ## How the addon works (architecture)

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.6.0</build.version>
+        <build.version>1.6.1</build.version>
         <build.number>-LOCAL</build.number>
     </properties>
 
@@ -277,25 +277,9 @@
                 <version>2.8.2</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
-                <configuration>
-                    <minimizeJar>true</minimizeJar>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.13</version>
                 <configuration>
                     <append>true</append>
                     <excludes>

--- a/src/main/java/world/bentobox/voidportals/listeners/VoidListener.java
+++ b/src/main/java/world/bentobox/voidportals/listeners/VoidListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.util.Vector;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.util.teleport.SafeSpotTeleport;
@@ -104,6 +105,12 @@ public class VoidListener implements Listener {
                 .entity(player)
                 .location(destination)
                 .portal()
+                // Cancel the void-fall momentum once the player arrives, otherwise the
+                // downward velocity carries over and slams them to their death.
+                .thenRun(() -> {
+                    player.setVelocity(new Vector(0, 0, 0));
+                    player.setFallDistance(0);
+                })
                 .build();
     }
 }


### PR DESCRIPTION
## What

Players falling into the void built up large downward velocity that carried over through `SafeSpotTeleport`, slamming them into the ground and killing them the instant they arrived in the next dimension. This zeroes out the player's velocity and fall distance in the teleport's `thenRun` callback so they land safely.

## Changes

- **Fix:** reset velocity + fall distance on arrival in `VoidListener.onPlayerFallIntoVoid`
- **Version:** bump `1.6.0` → `1.6.1`
- **Build:** bump JaCoCo `0.8.10` → `0.8.13` so coverage instruments class files built on JDK 25 (major version 69)
- **Cleanup:** remove the unused `maven-shade-plugin` — every dependency is `provided`/`test` scope, so there was nothing to shade; updated `CLAUDE.md` accordingly

## Testing

`mvn clean package` — all 16 tests pass, coverage runs clean on JDK 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)